### PR TITLE
Multiple authors

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,14 @@ func handlePath(path string) error {
 	// Initialize buffered reader for stdout.
 	buf := bufio.NewReader(stdout)
 
+	var authors []string
+	if *author != "" {
+		authors = strings.Split(*author, ",")
+		for i, a := range authors {
+			authors[i] = strings.Trim(a, " ")
+		}
+	}
+
 	// Read commit timestamps line by line. Parse in ISO8601 format, which is
 	// virtually identical to RFC3339.
 	for {
@@ -62,8 +70,17 @@ func handlePath(path string) error {
 		}
 		line = strings.TrimSuffix(line, "\n")
 		pieces := strings.SplitN(line, " ", 2)
-		if *author != "" && pieces[1] != *author {
-			continue
+		if *author != "" {
+			found := false
+			for _, a := range authors {
+				if pieces[1] == a {
+					found = true
+					continue
+				}
+			}
+			if !found {
+				continue
+			}
 		}
 		parse, err := time.Parse(timeFormat, pieces[0][:10])
 		if err != nil {

--- a/readme.md
+++ b/readme.md
@@ -43,4 +43,34 @@ a list of repository every time.
 
 ![](https://i.imgur.com/FW0cp6M.png)
 
+## Author
+
+[Xudong Zheng](https://www.xudongz.com/) 
+
+## License
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,10 @@ You can limit it to a specific user by specifying their email address.
 
 `gitstreak -author user@example.org path/to/repo`
 
+You can name multiple email addresses by separating them by a comma.
+
+`gitstreak -author user@example.org,another@example.org path/to/repo`
+
 If you have a single directory with all your repositories, you can easily
 include each repository.
 


### PR DESCRIPTION
Allow specifing multiple authors email addresses.

E.g.:

`gitstreak -author user@example.org,another@example.org path/to/repo`
